### PR TITLE
Implement toolchain detection on Windows

### DIFF
--- a/toolchain/private/detect.py
+++ b/toolchain/private/detect.py
@@ -1,11 +1,17 @@
 import os
 import platform
 import sys
+from pathlib import Path
+import shutil
 
 if platform.system() == "FreeBSD":
     path = os.popen("readlink -f /usr/local/gcc-arm-embedded", mode = "r").read()
 elif platform.system() == "Linux":
     path = "/usr"
+elif platform.system() == "Windows":
+    # Ask GCC for its own location, in case we've found a shim (e.g. Chocolatey)
+    sysroot = os.popen("arm-none-eabi-gcc -print-sysroot", mode = "r")
+    path = Path(sysroot.read()).parent.resolve().as_posix()
 else:
     print(f"Don't know how to detect toolchain path on {platform.system()}", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
Thanks for this great project! Satisfying all of us weirdos who want to use Bazel for embedded work :-)

As a double-weirdo, here is an extension of detect.py for a Windows environment.