### PR TITLE
Support setting PICO_CONFIG_RTOS_ADAPTER_HEADER

### DIFF
--- a/pico/BUILD.pico-sdk
+++ b/pico/BUILD.pico-sdk
@@ -73,6 +73,11 @@ cc_binary(
         "@platforms//os:none",
         "@platforms//cpu:armv6-m",
     ],
+    local_defines = [
+        # Workaround for https://github.com/raspberrypi/pico-sdk/issues/950
+         "__PICO_STRING(x)=#x",
+         "__PICO_XSTRING(x)=__PICO_STRING(x)",
+    ],
     deps = [
         "src/rp2_common/boot_stage2/boot_stage2.ld",
         ":boot_stage2_asm",
@@ -224,13 +229,26 @@ cc_library(
         ":boards",
         ":cmsis",
         ":pico_board_flag",
-    ],
+    ] + select({
+        ":rtos_adapter_enable": [
+            "@rules_pico//pico/config:rtos_adapter_header",
+            ":pico_config_rtos_adapter_header_flag",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 format_flag_string_value(
     name = "pico_board_flag",
     flag_name = "PICO_BOARD",
     flag_value = "@rules_pico//pico/config:board",
+)
+
+format_flag_string_value(
+    name = "pico_config_rtos_adapter_header_flag",
+    flag_name = "PICO_CONFIG_RTOS_ADAPTER_HEADER",
+    flag_value = "@rules_pico//pico/config:rtos_adapter_header_name",
+    quote = False,
 )
 
 config_autogen(
@@ -412,6 +430,7 @@ pico_sdk_library(
     incdir = "src/rp2_common/pico_malloc/include",
     deps = [
         ":pico_platform",
+        ":pico_sync",  # if PICO_USE_MALLOC_MUTEX
     ],
     alwayslink = True,
 )
@@ -600,6 +619,7 @@ pico_sdk_library(
     "stdio_uart",
     "stdio_usb",
     "stdio_semihosting",
+    "rtos_adapter_enable",
 ]]
 
 alias(

--- a/pico/config/BUILD
+++ b/pico/config/BUILD
@@ -70,3 +70,18 @@ bool_flag(
     name = "stdio_semihosting",
     build_setting_default = False,
 )
+
+bool_flag(
+    name = "rtos_adapter_enable",
+    build_setting_default = False,
+)
+
+label_flag(
+    name = "rtos_adapter_header",
+    build_setting_default = "@//:please-set-the-rtos_adapter_header-and-rtos_adapter_header_name-flags",
+)
+
+string_flag(
+    name = "rtos_adapter_header_name",
+    build_setting_default = "",
+)

--- a/pico/private/defs.bzl
+++ b/pico/private/defs.bzl
@@ -52,10 +52,14 @@ def pico_simple_hardware_target(*, name, deps = [], **kwargs):
     )
 
 def _format_flag_string_value_impl(ctx):
+    if ctx.attr.quote:
+        fmt = "{}=\"{}\""
+    else:
+        fmt = "{}={}"
     return CcInfo(
         compilation_context = cc_common.create_compilation_context(
             defines = depset([
-                "{}=\"{}\"".format(
+                fmt.format(
                     ctx.attr.flag_name,
                     ctx.attr.flag_value[BuildSettingInfo].value,
                 ),
@@ -68,6 +72,7 @@ format_flag_string_value = rule(
     attrs = {
         "flag_name": attr.string(),
         "flag_value": attr.label(),
+        "quote": attr.bool(default=True),
     },
 )
 


### PR DESCRIPTION
This adds some config flags that allow the user to set PICO_CONFIG_RTOS_ADAPTER_HEADER and inject a corresponding dependency into the appropriate place in the build graph.

Includes a necessary workaround for https://github.com/raspberrypi/pico-sdk/issues/950, which if that's fixed, I think will continue to work but produce warnings.

Adds a dependency from pico_malloc to pico_sync, which is required if PICO_USE_MALLOC_MUTEX=1 (which the [FreeRTOS config for rp2040 defines](https://github.com/FreeRTOS/FreeRTOS-Kernel/blob/smp/portable/ThirdParty/GCC/RP2040/include/freertos_sdk_config.h)).

Let me know if you'd like me to add something to the README.md, or somewhere else, documenting these new flags :)