### PR TITLE
Improve toolchain detection on Windows

### DIFF
--- a/toolchain/private/detect.py
+++ b/toolchain/private/detect.py
@@ -9,9 +9,17 @@ if platform.system() == "FreeBSD":
 elif platform.system() == "Linux":
     path = "/usr"
 elif platform.system() == "Windows":
+    gcc = shutil.which('arm-none-eabi-gcc')
+    if not gcc:
+        print(f"arm-none-eabi-gcc not found on PATH", file=sys.stderr)
+        sys.exit(1)
     # Ask GCC for its own location, in case we've found a shim (e.g. Chocolatey)
-    sysroot = os.popen("arm-none-eabi-gcc -print-sysroot", mode = "r")
-    path = Path(sysroot.read()).parent.resolve().as_posix()
+    sysroot = os.popen(f"{gcc} -print-sysroot", mode = "r").read()
+    if sysroot and not sysroot.isspace():
+        path = Path(sysroot).parent.resolve().as_posix()
+    else:
+        # Some installs don't know their own sysroot. Use the binary's location.
+        path = Path(gcc).parent.parent.resolve().as_posix()
 else:
     print(f"Don't know how to detect toolchain path on {platform.system()}", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
My previous attempt at this was pretty brittle, and didn't work for the [zipped GCC downloads at arm.com](https://developer.arm.com/downloads/-/gnu-rm), which don't have a sysroot string compiled in.