### PR TITLE
Add support for pico_cyw43_arch

### DIFF
--- a/pico/BUILD
+++ b/pico/BUILD
@@ -27,7 +27,7 @@
     "hardware_vreg",
     "hardware_watchdog",
     "hardware_xosc",
-
+    "pico_cyw43_arch",
     "pico_multicore",
     "pico_stdlib",
     "pico_sync",

--- a/pico/BUILD.pico-sdk
+++ b/pico/BUILD.pico-sdk
@@ -311,6 +311,15 @@ pico_sdk_library(
     ],
 )
 
+pico_sdk_library(
+    name = "pico_cyw43_arch",
+    srcdir = "src/rp2_common/pico_cyw43_arch",
+    incdir = "src/rp2_common/pico_cyw43_arch/include",
+    deps = [
+        ":pico_platform",
+    ],
+)
+
 alias(
     name = "pico_double",
     actual = "@rules_pico//pico/config:double_impl",


### PR DESCRIPTION
This adds support for the Pico W specific library `cyw43_arch`.

Note that this is far from ready for now - this library depends on the external `cyw43-driver` (in `lib/` in the Pico SDK), for which I need to write a `BUILD` file. Just putting this PR up for visibility for now.